### PR TITLE
ignore error if README doesn't exist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,11 @@
 from setuptools import setup
 import cgroupspy
 
-with open('README.md') as file:
-    long_description = file.read()
+try:
+    with open('README.md') as file:
+        long_description = file.read()
+except FileNotFoundError:
+    long_description = ""
 
 setup(
     name='cgroupspy',


### PR DESCRIPTION
ignore error if README doesn't exist (I couldn't install from pip because readme.md didn't exist in pypi package)
