### PR TITLE
Fix Python 3 support, restrict internals to bytes, use specific exceptions

### DIFF
--- a/cgroupspy/contenttypes.py
+++ b/cgroupspy/contenttypes.py
@@ -95,5 +95,5 @@ class DeviceThrottle(BaseContentType):
             major, minor = major_minor.split(":")
             return cls(int(limit), major, minor)
         except:
-            raise Exception("Value {} cannot be converted to a string that matches the pattern: "
-                            "[device major]:[device minor] [throttle limit in bytes]".format(value))
+            raise RuntimeError("Value {} cannot be converted to a string that matches the pattern: "
+                               "[device major]:[device minor] [throttle limit in bytes]".format(value))


### PR DESCRIPTION
Python 3 replaced byte strings with Unicode by default. This broke `cgroupspy` badly, even rendering it unable to construct a basic tree because of data type conflicts. This patch explicitly restricts all data flows except user output to bytes once again.

Moreover, exceptions have been refined to more accurately represent the nature of the problem.

Compatible with both 2.7 and 3.5. It _should_ be working but couldn't test for all use cases since I don't run VMs.
