### PR TITLE
interfaces: add support for empty strings

### DIFF
--- a/cgroupspy/interfaces.py
+++ b/cgroupspy/interfaces.py
@@ -177,10 +177,13 @@ class CommaDashSetFile(BaseFileInterface):
                 for el in range(int(start), int(end) + 1):
                     elems.append(el)
             else:
-                elems.append(int(el_group))
+                if el_group != '':
+                    elems.append(int(el_group))
         return set(elems)
 
     def sanitize_set(self, value):
+        if len(value) == 0:
+            return ' '
         try:
             value = value.encode()
         except AttributeError:

--- a/cgroupspy/test/test_interfaces.py
+++ b/cgroupspy/test/test_interfaces.py
@@ -103,9 +103,13 @@ class InterfacesTest(TestCase):
         self.assertEqual(fh.face, {1, 2, 3})
         self.assertEqual(fh.val, "1,2,3")
 
-        fh.face = 1
+        fh.face = {1}
         self.assertEqual(fh.face, {1})
         self.assertEqual(fh.val, "1")
+
+        fh.face = {}
+        self.assertEqual(fh.face, set([]))
+        self.assertEqual(fh.val, " ")
 
     def test_dict_file(self):
         self.patch_face(face=DictFile("dictfile"))


### PR DESCRIPTION
If a cpuset is empty return an empty set instead of failing. Also allow
writing an empty set instead of not writing.

Signed-off-by: Henning Schild henning@hennsch.de
