### PR TITLE
fix error: cant' mix strings and bytes in path components

### DIFF
--- a/cgroupspy/nodes.py
+++ b/cgroupspy/nodes.py
@@ -153,6 +153,7 @@ class Node(object):
         Delete a cgroup by name and detach it from this node.
         Raises OSError if the cgroup is not empty.
         """
+        name = name.encode()
         fp = os.path.join(self.full_path, name)
         if os.path.exists(fp):
             os.rmdir(fp)


### PR DESCRIPTION
see https://github.com/cloudsigma/cgroupspy/issues/7 for description. tested only in python2 (2.7.6) and python3 (3.4.3) REPL's.
